### PR TITLE
Fix lua error (#151)

### DIFF
--- a/lua/easychat/client/vgui/emote_picker.lua
+++ b/lua/easychat/client/vgui/emote_picker.lua
@@ -116,7 +116,7 @@ local PICKER = {
 				local i = 1
 				for emote_name, _ in pairs(lookup_table) do
 					if i >= 50 then break end -- lets stop adding
-					if (not no_search and emote_name:match(search)) or no_search then
+					if (not no_search and emote_name:find(search, nil, true)) or no_search then
 						local succ, emote = pcall(function() return providers[lookup_name](emote_name) end)
 						if succ and emote ~= false then
 							local set_emote_material = function() end


### PR DESCRIPTION
Fixes:
```
- malformed pattern (missing ']')
1. match - [C]:-1
 2. Populate - addons/easychat-master/lua/easychat/client/vgui/emote_picker.lua:119
  3. <unknown> - addons/easychat-master/lua/easychat/client/vgui/emote_picker.lua:26
```