### PR TITLE
Fix macro lua error (#164)

### DIFF
--- a/lua/easychat/client/macro_processor.lua
+++ b/lua/easychat/client/macro_processor.lua
@@ -199,7 +199,7 @@ function macro_processor:LoadSavedMacros()
 		local json = file.Read(path, "DATA")
 
 		local macro = util.JSONToTable(json)
-		if macro.IsLua and not self:CompileLuaMacro(macro) then return end
+		if not macro or macro.IsLua and not self:CompileLuaMacro(macro) then return end
 		self.Macros[macro_name] = macro
 	end
 end


### PR DESCRIPTION
If you try to open a macro with an invalid json structure, an error will occur that will break the entire EasyChat